### PR TITLE
fix histogram bar chart plotting

### DIFF
--- a/clahe_equalization.py
+++ b/clahe_equalization.py
@@ -61,6 +61,7 @@ def hist_lines(hist):
     cv2.normalize(hist, hist, 0, 255, cv2.NORM_MINMAX)
     hist = np.int32(np.around(hist))
     for x, y in enumerate(hist):
+        y = y[0]
         cv2.line(h, (x, 0), (x, y), (0, 0, 0))  # black bars
     y = np.flipud(h)
     return y

--- a/contrast_stretching.py
+++ b/contrast_stretching.py
@@ -61,6 +61,7 @@ def hist_lines(hist):
     cv2.normalize(hist, hist, 0, 255, cv2.NORM_MINMAX)
     hist = np.int32(np.around(hist))
     for x, y in enumerate(hist):
+        y = y[0]
         cv2.line(h, (x, 0), (x, y), (0, 0, 0))  # black bars
     y = np.flipud(h)
     return y

--- a/histogram.py
+++ b/histogram.py
@@ -72,6 +72,7 @@ def hist_lines(hist):
     cv2.normalize(hist, hist, 0, 255, cv2.NORM_MINMAX)
     hist = np.int32(np.around(hist))
     for x, y in enumerate(hist):
+        y = y[0]
         cv2.line(h, (x, 0), (x, y), (0, 0, 0))  # black bars
     y = np.flipud(h)
     return y

--- a/histogram_equalize.py
+++ b/histogram_equalize.py
@@ -61,6 +61,7 @@ def hist_lines(hist):
     cv2.normalize(hist, hist, 0, 255, cv2.NORM_MINMAX)
     hist = np.int32(np.around(hist))
     for x, y in enumerate(hist):
+        y = y[0]
         cv2.line(h, (x, 0), (x, y), (0, 0, 0))  # black bars
     y = np.flipud(h)
     return y


### PR DESCRIPTION
Python 3.9.1 / CV 4.5.1

Error in `histogram.py` / `clahe_equalization.py` / `contrast_stretching.py` / `histogram_equalize.py`

```
Traceback (most recent call last):
  File "/.../python-examples-ip/histogram.py", line 136, in <module>
    hist_img = hist_lines(hist)
  File "/.../python-examples-ip/histogram.py", line 75, in hist_lines
    cv2.line(h, (x, 0), (x, y), (0, 0, 0))  # black bars
TypeError: only integer scalar arrays can be converted to a scalar index
```

Cause:

`hist = cv2.calcHist([gray_img], [0], None, [256], [0, 256])`
returns 256x1 array, hence y val must be unpacked for plotting the bar chart
